### PR TITLE
Rename instance variable

### DIFF
--- a/lib/structured_data/rails_extentions/breadcrumb_list.rb
+++ b/lib/structured_data/rails_extentions/breadcrumb_list.rb
@@ -7,12 +7,12 @@ module StructuredData
       end
 
       def breadcrumb_list(&block)
-        @breadcrumb_list ||= StructuredData::BreadcrumbList.new
+        @structured_data_breadcrumb_list ||= StructuredData::BreadcrumbList.new
 
         if block_given?
-          @breadcrumb_list.instance_eval(&block)
+          @structured_data_breadcrumb_list.instance_eval(&block)
         else
-          @breadcrumb_list
+          @structured_data_breadcrumb_list
         end
       end
 


### PR DESCRIPTION
Fixed conflicts when the controller or views has a variable with same name.
